### PR TITLE
#6- Error in installing ivtmetrics resolved

### DIFF
--- a/ivtmetrics/recognition.py
+++ b/ivtmetrics/recognition.py
@@ -66,8 +66,8 @@ class Recognition(Disentangle):
     ##%%%%%%%%%%%%%%%%%%% RESET OP #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     def reset(self):
         "call at the beginning of new experiment or epoch to reset the accumulators for preditions and groundtruths."
-        self.predictions = np.empty(shape = [0,self.num_class], dtype=np.float)
-        self.targets     = np.empty(shape = [0,self.num_class], dtype=np.int)        
+        self.predictions = np.empty(shape = [0,self.num_class], dtype=np.float32)
+        self.targets     = np.empty(shape = [0,self.num_class], dtype=np.int32)
         
     def reset_global(self):
         "call at the beginning of new experiment"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 from pathlib import Path
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.rst").read_text()
+long_description = (this_directory / "README.rst").read_text(encoding="utf-8")
 
 setup(
     name='ivtmetrics',


### PR DESCRIPTION
Add encoding='utf=8' to the read_text() method so that same error won't occur again.

I tested locally and it is working.

You may review and approve the PR.